### PR TITLE
Wrap Iterator + Countable in CountableProviderRecord

### DIFF
--- a/src/Porter.php
+++ b/src/Porter.php
@@ -63,12 +63,7 @@ class Porter
         $records = $this->fetch($specification->getResource(), $specification->getCacheAdvice());
 
         if (!$records instanceof ProviderRecords) {
-            // Wrap Iterator in ProviderRecords.
-            if ($records instanceof \Countable) {
-                $records = new CountableProviderRecords($records, count($records), $specification->getResource());
-            } else {
-                $records = new ProviderRecords($records, $specification->getResource());
-            }
+            $this->createProviderRecords($records, $specification->getResource());
         }
 
         if ($specification->getFilter()) {
@@ -106,6 +101,15 @@ class Porter
         }
 
         return $one;
+    }
+
+    private function createProviderRecords(\Iterator $records, ProviderResource $resource)
+    {
+        if ($records instanceof \Countable) {
+            return new CountableProviderRecords($records, count($records), $resource);
+        }
+
+        return new ProviderRecords($records, $resource);
     }
 
     private function createPorterRecords(RecordCollection $records, ImportSpecification $specification)

--- a/src/Porter.php
+++ b/src/Porter.php
@@ -8,6 +8,7 @@ use ScriptFUSION\Porter\Cache\CacheToggle;
 use ScriptFUSION\Porter\Cache\CacheUnavailableException;
 use ScriptFUSION\Porter\Collection\CountableMappedRecords;
 use ScriptFUSION\Porter\Collection\CountablePorterRecords;
+use ScriptFUSION\Porter\Collection\CountableProviderRecords;
 use ScriptFUSION\Porter\Collection\FilteredRecords;
 use ScriptFUSION\Porter\Collection\MappedRecords;
 use ScriptFUSION\Porter\Collection\PorterRecords;
@@ -63,7 +64,11 @@ class Porter
 
         if (!$records instanceof ProviderRecords) {
             // Wrap Iterator in ProviderRecords.
-            $records = new ProviderRecords($records, $specification->getResource());
+            if ($records instanceof \Countable) {
+                $records = new CountableProviderRecords($records, count($records), $specification->getResource());
+            } else {
+                $records = new ProviderRecords($records, $specification->getResource());
+            }
         }
 
         if ($specification->getFilter()) {

--- a/src/Porter.php
+++ b/src/Porter.php
@@ -63,7 +63,7 @@ class Porter
         $records = $this->fetch($specification->getResource(), $specification->getCacheAdvice());
 
         if (!$records instanceof ProviderRecords) {
-            $this->createProviderRecords($records, $specification->getResource());
+            $records = $this->createProviderRecords($records, $specification->getResource());
         }
 
         if ($specification->getFilter()) {

--- a/test/Integration/Porter/PorterTest.php
+++ b/test/Integration/Porter/PorterTest.php
@@ -172,6 +172,18 @@ final class PorterTest extends \PHPUnit_Framework_TestCase
         self::assertCount($count, $records);
     }
 
+    public function testImportAndMapNonCountableRecords()
+    {
+        $records = $this->porter->import(
+            (new StaticDataImportSpecification(
+                new ProviderRecords($this->iterateOne(), $this->resource)
+            ))->setMapping(\Mockery::mock(Mapping::class))
+        );
+
+        self::assertInstanceOf(CountableMappedRecords::class, $records->getPreviousCollection());
+        self::assertInstanceOf(\Countable::class, $records);
+    }
+
     /**
      * Tests that when the resource is countable the count is propagated to the outermost collection via a mapped
      * collection.
@@ -184,9 +196,10 @@ final class PorterTest extends \PHPUnit_Framework_TestCase
             ))->setMapping(\Mockery::mock(Mapping::class))
         );
 
-        self::assertInstanceOf(CountableMappedRecords::class, $records->getPreviousCollection());
-        self::assertInstanceOf(\Countable::class, $records);
-        self::assertCount($count, $records);
+        self::assertNotInstanceOf(MappedRecords::class, $records->getPreviousCollection());
+        self::assertNotInstanceOf(\Iterator::class, $records);
+        self::assertNotInstanceOf(CountableMappedRecords::class, $records->getPreviousCollection());
+        self::assertNotInstanceOf(\Countable::class, $records);
     }
 
     /**

--- a/test/Integration/Porter/PorterTest.php
+++ b/test/Integration/Porter/PorterTest.php
@@ -127,15 +127,11 @@ final class PorterTest extends \PHPUnit_Framework_TestCase
 
     public function testNonCountableIteratorImport()
     {
-        $porter = (new Porter)->registerProvider(
-            $this->provider =
-                \Mockery::mock(Provider::class)
-                    ->shouldReceive('fetch')
-                    ->andReturn($this->iterateOne())
-                    ->byDefault()
-                    ->getMock()
-        );
-        $records = $porter->import($this->specification);
+        $this->provider->shouldReceive('fetch')->andReturnUsing(function () {
+            yield 'foo';
+        });
+
+        $records = $this->porter->import($this->specification);
 
         self::assertInstanceOf(PorterRecords::class, $records);
         self::assertNotSame($this->specification, $records->getSpecification());
@@ -174,9 +170,13 @@ final class PorterTest extends \PHPUnit_Framework_TestCase
 
     public function testImportAndMapNonCountableRecords()
     {
+        /** @var \Generator $iterateOne */
+        $iterateOne = function () {
+            yield 'foo';
+        };
         $records = $this->porter->import(
             (new StaticDataImportSpecification(
-                new ProviderRecords($this->iterateOne(), $this->resource)
+                new ProviderRecords($iterateOne, $this->resource)
             ))->setMapping(\Mockery::mock(Mapping::class))
         );
 

--- a/test/Integration/Porter/PorterTest.php
+++ b/test/Integration/Porter/PorterTest.php
@@ -141,14 +141,6 @@ final class PorterTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Iterates over one value.
-     */
-    private function iterateOne()
-    {
-        yield 'foo';
-    }
-
-    /**
      * Tests that when the resource is countable the count is propagated to the outermost collection.
      */
     public function testImportCountableRecords()

--- a/test/Integration/Porter/PorterTest.php
+++ b/test/Integration/Porter/PorterTest.php
@@ -162,13 +162,12 @@ final class PorterTest extends \PHPUnit_Framework_TestCase
 
     public function testImportAndMapNonCountableRecords()
     {
-        /** @var \Generator $iterateOne */
         $iterateOne = function () {
             yield 'foo';
         };
         $records = $this->porter->import(
             (new StaticDataImportSpecification(
-                new ProviderRecords($iterateOne, $this->resource)
+                new ProviderRecords($iterateOne(), $this->resource)
             ))->setMapping(\Mockery::mock(Mapping::class))
         );
 

--- a/test/Integration/Porter/PorterTest.php
+++ b/test/Integration/Porter/PorterTest.php
@@ -180,8 +180,8 @@ final class PorterTest extends \PHPUnit_Framework_TestCase
             ))->setMapping(\Mockery::mock(Mapping::class))
         );
 
-        self::assertNotInstanceOf(MappedRecords::class, $records->getPreviousCollection());
-        self::assertNotInstanceOf(\Iterator::class, $records);
+        self::assertInstanceOf(MappedRecords::class, $records->getPreviousCollection());
+        self::assertInstanceOf(\Iterator::class, $records);
         self::assertNotInstanceOf(CountableMappedRecords::class, $records->getPreviousCollection());
         self::assertNotInstanceOf(\Countable::class, $records);
     }

--- a/test/Integration/Porter/PorterTest.php
+++ b/test/Integration/Porter/PorterTest.php
@@ -180,8 +180,10 @@ final class PorterTest extends \PHPUnit_Framework_TestCase
             ))->setMapping(\Mockery::mock(Mapping::class))
         );
 
-        self::assertInstanceOf(CountableMappedRecords::class, $records->getPreviousCollection());
-        self::assertInstanceOf(\Countable::class, $records);
+        self::assertNotInstanceOf(MappedRecords::class, $records->getPreviousCollection());
+        self::assertNotInstanceOf(\Iterator::class, $records);
+        self::assertNotInstanceOf(CountableMappedRecords::class, $records->getPreviousCollection());
+        self::assertNotInstanceOf(\Countable::class, $records);
     }
 
     /**
@@ -196,10 +198,9 @@ final class PorterTest extends \PHPUnit_Framework_TestCase
             ))->setMapping(\Mockery::mock(Mapping::class))
         );
 
-        self::assertNotInstanceOf(MappedRecords::class, $records->getPreviousCollection());
-        self::assertNotInstanceOf(\Iterator::class, $records);
-        self::assertNotInstanceOf(CountableMappedRecords::class, $records->getPreviousCollection());
-        self::assertNotInstanceOf(\Countable::class, $records);
+        self::assertInstanceOf(CountableMappedRecords::class, $records->getPreviousCollection());
+        self::assertInstanceOf(\Countable::class, $records);
+        self::assertCount($count, $records);
     }
 
     /**

--- a/test/Integration/Porter/PorterTest.php
+++ b/test/Integration/Porter/PorterTest.php
@@ -121,8 +121,35 @@ final class PorterTest extends \PHPUnit_Framework_TestCase
 
         self::assertInstanceOf(PorterRecords::class, $records);
         self::assertNotSame($this->specification, $records->getSpecification());
-        self::assertInstanceOf(ProviderRecords::class, $records->getPreviousCollection());
+        self::assertInstanceOf(CountableProviderRecords::class, $records->getPreviousCollection());
         self::assertSame('foo', $records->current());
+    }
+
+    public function testNonCountableIteratorImport()
+    {
+        $porter = (new Porter)->registerProvider(
+            $this->provider =
+                \Mockery::mock(Provider::class)
+                    ->shouldReceive('fetch')
+                    ->andReturn($this->iterateOne())
+                    ->byDefault()
+                    ->getMock()
+        );
+        $records = $porter->import($this->specification);
+
+        self::assertInstanceOf(PorterRecords::class, $records);
+        self::assertNotSame($this->specification, $records->getSpecification());
+        self::assertInstanceOf(ProviderRecords::class, $records->getPreviousCollection());
+        self::assertNotInstanceOf(CountableProviderRecords::class, $records->getPreviousCollection());
+        self::assertSame('foo', $records->current());
+    }
+
+    /**
+     * Iterates over one value.
+     */
+    private function iterateOne()
+    {
+        yield 'foo';
     }
 
     /**


### PR DESCRIPTION
I've tried to create a resource with a $connector->fetch that returned a ArrayIterator (Countable) but the result was not an instance of Countable.
I solved using directly:
return new CountableProviderRecords($data, count($data), $this);
in the fetch method.
I thought if you pass an instance of countable this can be done directly by the import function.
