### PR TITLE
Added EncapsulatedOptions::merge() and accompanying test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
 
 install:
   - alias composer=composer\ -n && composer selfupdate

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   "license": "LGPL-3.0",
   "require": {
     "php": ">=5.5",
-    "scriptfusion/mapper": "^1|^0",
+    "scriptfusion/mapper": "^1",
     "scriptfusion/static-class": "^1",
     "scriptfusion/retry-error-handlers": "^1",
     "psr/cache": "^1",

--- a/src/Options/EncapsulatedOptions.php
+++ b/src/Options/EncapsulatedOptions.php
@@ -21,7 +21,8 @@ abstract class EncapsulatedOptions
     }
 
     /**
-     * Merges the specified overriding options into this instance giving precedence to the overriding options.
+     * Merges the specified overriding options into this instance giving precedence to the overriding options. Only
+     * option values that have been explicitly set are merged; that is, defaults are not merged.
      *
      * @param EncapsulatedOptions $overridingOptions Overriding options.
      */
@@ -31,22 +32,22 @@ abstract class EncapsulatedOptions
             throw new MergeException('Cannot merge: options must be an instance of "' . get_class($this) . '".');
         }
 
-        $this->options = $this->mergeOptions($overridingOptions);
+        $this->options = $this->mergeOptions($this->options, $overridingOptions->options);
     }
 
     /**
-     * Merges the specified overriding options with the options of this instance giving precedence to the overriding
-     * options.
+     * Merges the specified options with the specified overrides giving precedence to the overriding options.
      *
      * Overriding this method in a derived class allows it to implement a custom merging strategy.
      *
-     * @param EncapsulatedOptions $overridingOptions Overriding options.
+     * @param array $options Options of this instance.
+     * @param array $overrides Overriding options.
      *
      * @return array Merged options.
      */
-    protected function mergeOptions(EncapsulatedOptions $overridingOptions)
+    protected function mergeOptions(array $options, array $overrides)
     {
-        return $overridingOptions->copy() + $this->copy();
+        return $overrides + $options;
     }
 
     /**
@@ -90,6 +91,10 @@ abstract class EncapsulatedOptions
      */
     final protected function set($option, $value)
     {
+        if (is_object($value) || is_resource($value)) {
+            throw new \InvalidArgumentException('Value must not be an object or resource.');
+        }
+
         $this->options["$option"] = $value;
 
         return $this;

--- a/src/Options/EncapsulatedOptions.php
+++ b/src/Options/EncapsulatedOptions.php
@@ -31,28 +31,21 @@ abstract class EncapsulatedOptions
             throw new MergeException('Cannot merge: options must be an instance of "' . get_class($this) . '".');
         }
 
-        $this->options = $this->mergeOptions($overridingOptions, $overridingOptions->options, $this->options);
+        $this->options = $this->mergeOptions($overridingOptions);
     }
 
     /**
      * Merges the specified overriding options with the options of this instance giving precedence to the overriding
      * options.
      *
-     * Overriding this method in a derived class allows it to implement a custom merging strategy using the overriding
-     * options or the specified explicit overriding options and the specified explicit options of this instance.
-     * Explicit options are those set explicitly and exclude any default values.
+     * Overriding this method in a derived class allows it to implement a custom merging strategy.
      *
      * @param EncapsulatedOptions $overridingOptions Overriding options.
-     * @param array $explicitOverridingOptions Overriding options excluding defaults.
-     * @param array $explicitOptions This instance's options excluding defaults.
      *
      * @return array Merged options.
      */
-    protected function mergeOptions(
-        EncapsulatedOptions $overridingOptions,
-        array $explicitOverridingOptions,
-        array $explicitOptions
-    ) {
+    protected function mergeOptions(EncapsulatedOptions $overridingOptions)
+    {
         return $overridingOptions->copy() + $this->copy();
     }
 

--- a/src/Options/EncapsulatedOptions.php
+++ b/src/Options/EncapsulatedOptions.php
@@ -21,6 +21,42 @@ abstract class EncapsulatedOptions
     }
 
     /**
+     * Merges the specified overriding options into this instance giving precedence to the overriding options.
+     *
+     * @param EncapsulatedOptions $overridingOptions Overriding options.
+     */
+    final public function merge(EncapsulatedOptions $overridingOptions)
+    {
+        if (!$overridingOptions instanceof static) {
+            throw new MergeException('Cannot merge: options must be an instance of "' . get_class($this) . '".');
+        }
+
+        $this->options = $this->mergeOptions($overridingOptions, $overridingOptions->options, $this->options);
+    }
+
+    /**
+     * Merges the specified overriding options with the options of this instance giving precedence to the overriding
+     * options.
+     *
+     * Overriding this method in a derived class allows it to implement a custom merging strategy using the overriding
+     * options or the specified explicit overriding options and the specified explicit options of this instance.
+     * Explicit options are those set explicitly and exclude any default values.
+     *
+     * @param EncapsulatedOptions $overridingOptions Overriding options.
+     * @param array $explicitOverridingOptions Overriding options excluding defaults.
+     * @param array $explicitOptions This instance's options excluding defaults.
+     *
+     * @return array Merged options.
+     */
+    protected function mergeOptions(
+        EncapsulatedOptions $overridingOptions,
+        array $explicitOverridingOptions,
+        array $explicitOptions
+    ) {
+        return $overridingOptions->copy() + $this->copy();
+    }
+
+    /**
      * Gets the value for the specified option name. Returns the specified
      * default value if option name is not set.
      *

--- a/src/Options/MergeException.php
+++ b/src/Options/MergeException.php
@@ -1,0 +1,10 @@
+<?php
+namespace ScriptFUSION\Porter\Options;
+
+/**
+ * The exception that is thrown when options cannot be merged.
+ */
+final class MergeException extends \RuntimeException
+{
+    // Intentionall empty.
+}

--- a/test/Porter/Options/TestOptions.php
+++ b/test/Porter/Options/TestOptions.php
@@ -3,7 +3,7 @@ namespace ScriptFUSIONTest\Porter\Options;
 
 use ScriptFUSION\Porter\Options\EncapsulatedOptions;
 
-final class TestOptions extends EncapsulatedOptions
+class TestOptions extends EncapsulatedOptions
 {
     public function __construct()
     {

--- a/test/Unit/Porter/Options/EncapsulatedOptionsTest.php
+++ b/test/Unit/Porter/Options/EncapsulatedOptionsTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace ScriptFUSIONTest\Unit\Porter\Options;
 
+use ScriptFUSION\Porter\Options\EncapsulatedOptions;
+use ScriptFUSION\Porter\Options\MergeException;
 use ScriptFUSIONTest\Porter\Options\TestOptions;
 
 final class EncapsulatedOptionsTest extends \PHPUnit_Framework_TestCase
@@ -39,6 +41,43 @@ final class EncapsulatedOptionsTest extends \PHPUnit_Framework_TestCase
         $this->options->setFoo('bar');
 
         self::assertSame(['foo' => 'bar'], $this->options->copy());
+    }
+
+    public function testMerge()
+    {
+        $a = $this->options;
+        $b = (new TestOptions)->setFoo('bar');
+        $c = clone $a;
+
+        self::assertSame('foo', $a->getFoo());
+        self::assertSame('bar', $b->getFoo());
+        self::assertSame('foo', $c->getFoo());
+
+        $c->merge($b);
+
+        self::assertSame('foo', $a->getFoo());
+        self::assertSame('bar', $b->getFoo());
+        self::assertSame('bar', $c->getFoo());
+
+        $c->merge($a);
+
+        self::assertSame('foo', $a->getFoo());
+        self::assertSame('bar', $b->getFoo());
+        self::assertSame('foo', $c->getFoo());
+    }
+
+    public function testMergeDerivedClass()
+    {
+        $this->options->merge(\Mockery::mock(TestOptions::class));
+
+        // PHPUnit asserts no exception is thrown.
+    }
+
+    public function testMergeNonDerivedClass()
+    {
+        $this->setExpectedException(MergeException::class, TestOptions::class);
+
+        $this->options->merge(\Mockery::mock(EncapsulatedOptions::class));
     }
 
     public function testGetReference()

--- a/test/Unit/Porter/Options/EncapsulatedOptionsTest.php
+++ b/test/Unit/Porter/Options/EncapsulatedOptionsTest.php
@@ -27,6 +27,20 @@ final class EncapsulatedOptionsTest extends \PHPUnit_Framework_TestCase
         self::assertSame('bar', $this->options->getFoo());
     }
 
+    public function testSetObject()
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+
+        $this->options->setFoo($this->options);
+    }
+
+    public function testSetResource()
+    {
+        $this->setExpectedException(\InvalidArgumentException::class);
+
+        $this->options->setFoo(STDIN);
+    }
+
     public function testSetNullOverridesDefault()
     {
         $this->options->setFoo(null);
@@ -53,12 +67,22 @@ final class EncapsulatedOptionsTest extends \PHPUnit_Framework_TestCase
         self::assertSame('bar', $b->getFoo());
         self::assertSame('foo', $c->getFoo());
 
+        // Merging in b sets c to 'bar'.
         $c->merge($b);
 
         self::assertSame('foo', $a->getFoo());
         self::assertSame('bar', $b->getFoo());
         self::assertSame('bar', $c->getFoo());
 
+        // Merging in a does not change the value of c because no options have been set explicitly for a.
+        $c->merge($a);
+
+        self::assertSame('foo', $a->getFoo());
+        self::assertSame('bar', $b->getFoo());
+        self::assertSame('bar', $c->getFoo());
+
+        // Merging in a sets c to 'foo' after it has been explicitly set for a.
+        $a->setFoo('foo');
         $c->merge($a);
 
         self::assertSame('foo', $a->getFoo());


### PR DESCRIPTION
This PR implements option merging for `EncapsulatedOptions` such that two compatible instances may be merged into each other. This is a common use case since a provider may supply options and a resource supplies its own superset of the same options class which need to be combined before they're forwarded to the connector.

There are some interesting questions raised by this.
1. Should the merged options become a new instance or modify one of the existing instances?
2. Should merging consider only the options or copy in the default values as well?
   1. If it should consider defaults, should it do so for one or both instances?
3. What should be the default merge strategy? Is a simple union sufficient or should it be recursive?
4. How should merging be implemented in a derived class? Simple method override or strategy pattern?

Currently this PR implements the following answers to these questions, subject to change.
1. Existing instance is mutated.
2. Only options are considered, default values are ignored.
3. Simple array union of options.
4. Simple method override.
