### PR TITLE
Moved durability and cache state out of Porter into ImportSpecification

### DIFF
--- a/src/Porter.php
+++ b/src/Porter.php
@@ -36,11 +36,6 @@ class Porter
     private $providerFactory;
 
     /**
-     * @var CacheAdvice
-     */
-    private $defaultCacheAdvice;
-
-    /**
      * @var int
      */
     private $maxFetchAttempts = self::DEFAULT_FETCH_ATTEMPTS;
@@ -49,11 +44,6 @@ class Porter
      * @var callable
      */
     private $fetchExceptionHandler;
-
-    public function __construct()
-    {
-        $this->defaultCacheAdvice = CacheAdvice::SHOULD_NOT_CACHE();
-    }
 
     /**
      * Imports data according to the design of the specified import specification.
@@ -108,7 +98,7 @@ class Porter
     {
         $provider = $this->getProvider($resource->getProviderClassName(), $resource->getProviderTag());
 
-        $this->applyCacheAdvice($provider, $cacheAdvice ?: $this->defaultCacheAdvice);
+        $this->applyCacheAdvice($provider, $cacheAdvice);
 
         if (($records = \ScriptFUSION\Retry\retry(
             $this->getMaxFetchAttempts(),

--- a/src/Specification/ImportSpecification.php
+++ b/src/Specification/ImportSpecification.php
@@ -26,14 +26,21 @@ class ImportSpecification
     private $context;
 
     /**
-     * @var CacheAdvice
+     * @var CacheAdvice|null
      */
     private $cacheAdvice;
+
+    /**
+     * @var CacheAdvice
+     */
+    private $defaultCacheAdvice;
 
     public function __construct(ProviderResource $resource)
     {
         $this->resource = $resource;
+
         $this->clearTransformers();
+        $this->defaultCacheAdvice = CacheAdvice::SHOULD_NOT_CACHE();
     }
 
     public function __clone()
@@ -141,7 +148,7 @@ class ImportSpecification
      */
     final public function getCacheAdvice()
     {
-        return $this->cacheAdvice;
+        return $this->cacheAdvice ?: $this->defaultCacheAdvice;
     }
 
     /**

--- a/test/Integration/Porter/PorterTest.php
+++ b/test/Integration/Porter/PorterTest.php
@@ -257,7 +257,7 @@ final class PorterTest extends \PHPUnit_Framework_TestCase
         $this->provider->shouldReceive('fetch')->once()->andThrow(RecoverableConnectorException::class);
 
         $this->setExpectedException(FailingTooHardException::class, '1');
-        $this->porter->setMaxFetchAttempts(1)->import($this->specification);
+        $this->porter->import($this->specification->setMaxFetchAttempts(1));
     }
 
     public function testDerivedRecoverableException()
@@ -265,15 +265,15 @@ final class PorterTest extends \PHPUnit_Framework_TestCase
         $this->provider->shouldReceive('fetch')->once()->andThrow(\Mockery::mock(RecoverableConnectorException::class));
 
         $this->setExpectedException(FailingTooHardException::class);
-        $this->porter->setMaxFetchAttempts(1)->import($this->specification);
+        $this->porter->import($this->specification->setMaxFetchAttempts(1));
     }
 
     public function testDefaultTries()
     {
-        $this->provider->shouldReceive('fetch')->times(Porter::DEFAULT_FETCH_ATTEMPTS)
+        $this->provider->shouldReceive('fetch')->times(ImportSpecification::DEFAULT_FETCH_ATTEMPTS)
             ->andThrow(RecoverableConnectorException::class);
 
-        $this->setExpectedException(FailingTooHardException::class, (string)Porter::DEFAULT_FETCH_ATTEMPTS);
+        $this->setExpectedException(FailingTooHardException::class, (string)ImportSpecification::DEFAULT_FETCH_ATTEMPTS);
         $this->porter->import($this->specification);
     }
 
@@ -287,13 +287,13 @@ final class PorterTest extends \PHPUnit_Framework_TestCase
 
     public function testCustomFetchExceptionHandler()
     {
-        $this->porter->setFetchExceptionHandler(
+        $this->specification->setFetchExceptionHandler(
             \Mockery::mock(ExponentialBackoffExceptionHandler::class)
                 ->shouldReceive('__invoke')
-                ->times(Porter::DEFAULT_FETCH_ATTEMPTS - 1)
+                ->times(ImportSpecification::DEFAULT_FETCH_ATTEMPTS - 1)
                 ->getMock()
         );
-        $this->provider->shouldReceive('fetch')->times(Porter::DEFAULT_FETCH_ATTEMPTS)
+        $this->provider->shouldReceive('fetch')->times(ImportSpecification::DEFAULT_FETCH_ATTEMPTS)
             ->andThrow(RecoverableConnectorException::class);
 
         $this->setExpectedException(FailingTooHardException::class);


### PR DESCRIPTION
Porter should not store any configuration state; that is the job of the specification. By moving durability options out of `Porter` and into `ImportSpecification`, durability can be configured per-import instead of for all imports performed by that Porter instance.

Default `CacheAdvice` should never have been present in `Porter` since cache has never been configured there.