### PR TITLE
Added DeepCopy to replace __clone implementations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
     "scriptfusion/retry": "^1.1",
     "scriptfusion/retry-exception-handlers": "^1",
     "eloquent/enumeration": "^5",
+    "myclabs/deep-copy": "^1",
     "psr/cache": "^1",
     "zendframework/zend-uri": "^2"
   },

--- a/src/Specification/ImportSpecification.php
+++ b/src/Specification/ImportSpecification.php
@@ -36,21 +36,6 @@ class ImportSpecification
         $this->clearTransformers();
     }
 
-    public function __clone()
-    {
-        $this->resource = clone $this->resource;
-
-        $transformers = $this->transformers;
-        $this->clearTransformers()->addTransformers(array_map(
-            function (Transformer $transformer) {
-                return clone $transformer;
-            },
-            $transformers
-        ));
-
-        is_object($this->context) && $this->context = clone $this->context;
-    }
-
     /**
      * @return ProviderResource
      */


### PR DESCRIPTION
This PR proposes implementing [DeepCopy](https://github.com/myclabs/DeepCopy) to avoid placing the burden on users to implement `__clone` in their transformers. However, that library currently suffers from a blocking issue (myclabs/Deepcopy#62) that prevents its adoption.