### PR TITLE
Refactored Porter to no longer be a repository of providers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
     "scriptfusion/retry": "^1.1",
     "scriptfusion/retry-exception-handlers": "^1",
     "eloquent/enumeration": "^5",
+    "psr/container": "^1",
     "psr/cache": "^1",
     "zendframework/zend-uri": "^2"
   },

--- a/src/Provider/Resource/StaticResource.php
+++ b/src/Provider/Resource/StaticResource.php
@@ -19,11 +19,6 @@ class StaticResource implements ProviderResource
         return StaticDataProvider::class;
     }
 
-    public function getProviderTag()
-    {
-        return;
-    }
-
     public function fetch(Connector $connector, EncapsulatedOptions $options = null)
     {
         return $this->data;

--- a/src/Specification/ImportSpecification.php
+++ b/src/Specification/ImportSpecification.php
@@ -21,7 +21,7 @@ class ImportSpecification
     /**
      * @var string
      */
-    private $providerTag;
+    private $providerName;
 
     /**
      * @var Transformer[]
@@ -86,30 +86,32 @@ class ImportSpecification
     }
 
     /**
-     * Gets the provider identifier tag.
+     * Gets the provider name.
      *
-     * @return string Provider tag.
+     * @return string Provider name.
      */
-    final public function getProviderTag()
+    final public function getProviderName()
     {
-        return $this->providerTag;
+        return $this->providerName;
     }
 
     /**
-     * Sets the provider identifier tag.
+     * Sets the provider name.
      *
-     * @param string $tag Provider tag.
+     * @param string $tag Provider name.
      *
      * @return $this
      */
-    final public function setProviderTag($tag)
+    final public function setProviderName($tag)
     {
-        $this->providerTag = "$tag";
+        $this->providerName = "$tag";
 
         return $this;
     }
 
     /**
+     * Gets the ordered list of transformers.
+     *
      * @return Transformer[]
      */
     final public function getTransformers()

--- a/test/Integration/Porter/Specification/StaticDataImportSpecificationTest.php
+++ b/test/Integration/Porter/Specification/StaticDataImportSpecificationTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace ScriptFUSIONTest\Integration\Porter\Specification;
 
+use Psr\Container\ContainerInterface;
 use ScriptFUSION\Porter\Porter;
 use ScriptFUSION\Porter\Specification\StaticDataImportSpecification;
 
@@ -11,7 +12,8 @@ final class StaticDataImportSpecificationTest extends \PHPUnit_Framework_TestCas
 {
     public function test()
     {
-        $records = (new Porter)->import(new StaticDataImportSpecification(new \ArrayIterator(['foo'])));
+        $records = (new Porter(\Mockery::spy(ContainerInterface::class)))
+            ->import(new StaticDataImportSpecification(new \ArrayIterator(['foo'])));
 
         self::assertSame('foo', $records->current());
     }

--- a/test/Unit/Porter/ImportSpecificationTest.php
+++ b/test/Unit/Porter/ImportSpecificationTest.php
@@ -56,7 +56,7 @@ final class ImportSpecificationTest extends \PHPUnit_Framework_TestCase
 
     public function testProviderTag()
     {
-        self::assertSame($tag = 'foo', $this->specification->setProviderTag($tag)->getProviderTag());
+        self::assertSame($tag = 'foo', $this->specification->setProviderName($tag)->getProviderName());
     }
 
     public function testAddTransformer()


### PR DESCRIPTION
* Porter now composes a container of providers received in its constructor instead of acting as a provider registry directly.
* Provider tags have been removed since they are redundant.
* Provider class name specified by resources can be overridden by calling `ImportSpecification::setProviderName`.