### PR TITLE
Added resource type parameter to Provider::getConnector

### DIFF
--- a/src/Collection/RecordCollection.php
+++ b/src/Collection/RecordCollection.php
@@ -10,7 +10,7 @@ abstract class RecordCollection implements \Iterator
 
     private $previousCollection;
 
-    public function __construct(\Iterator $records, RecordCollection $previousCollection = null)
+    public function __construct(\Iterator $records, self $previousCollection = null)
     {
         $this->records = $records;
         $this->previousCollection = $previousCollection;

--- a/src/Connector/CachingConnector.php
+++ b/src/Connector/CachingConnector.php
@@ -39,6 +39,7 @@ class CachingConnector implements Connector
     }
 
     /**
+     * @param ConnectionContext $context
      * @param string $source
      * @param EncapsulatedOptions|null $options
      *

--- a/src/Porter.php
+++ b/src/Porter.php
@@ -110,7 +110,7 @@ class Porter
         }
 
         $records = $resource->fetch(
-            new ImportConnector($provider->getConnector(), $context),
+            new ImportConnector($provider->getConnector(get_class($resource)), $context),
             $provider instanceof ProviderOptions ? clone $provider->getOptions() : null
         );
 

--- a/src/Provider/Provider.php
+++ b/src/Provider/Provider.php
@@ -4,14 +4,16 @@ namespace ScriptFUSION\Porter\Provider;
 use ScriptFUSION\Porter\Connector\Connector;
 
 /**
- * Provides a method for accessing a connector.
+ * Provides a method for getting a connector.
  */
 interface Provider
 {
     /**
-     * Gets a connector for accessing resource data.
+     * Gets a connector for fetching resource data.
+     *
+     * @param string $resourceType The resource type from which data will be fetched.
      *
      * @return Connector
      */
-    public function getConnector();
+    public function getConnector($resourceType);
 }

--- a/src/Provider/StaticDataProvider.php
+++ b/src/Provider/StaticDataProvider.php
@@ -12,7 +12,7 @@ class StaticDataProvider implements Provider
         $this->connector = new NullConnector;
     }
 
-    public function getConnector()
+    public function getConnector($resourceType)
     {
         return $this->connector;
     }

--- a/test/Integration/Porter/PorterTest.php
+++ b/test/Integration/Porter/PorterTest.php
@@ -68,7 +68,7 @@ final class PorterTest extends \PHPUnit_Framework_TestCase
         $this->porter = new Porter($this->container = \Mockery::spy(ContainerInterface::class));
 
         $this->registerProvider($this->provider = MockFactory::mockProvider());
-        $this->connector = $this->provider->getConnector();
+        $this->connector = $this->provider->getConnector('');
         $this->resource = MockFactory::mockResource($this->provider);
         $this->specification = new ImportSpecification($this->resource);
     }

--- a/test/MockFactory.php
+++ b/test/MockFactory.php
@@ -20,12 +20,13 @@ final class MockFactory
     {
         return \Mockery::namedMock(uniqid(Provider::class, false), Provider::class)
             ->shouldReceive('getConnector')
+                ->with(\Mockery::type('string'))
                 ->andReturn(
                     \Mockery::mock(Connector::class)
                         ->shouldReceive('fetch')
                         ->andReturn('foo')
-                        ->getMock()
                         ->byDefault()
+                        ->getMock()
                 )
             ->getMock()
         ;


### PR DESCRIPTION
Following up on the TODO comment from #41, this PR doesn't pass the resource to `Provider::getConnector`, but rather, just the resource's type. I don't feel comfortable passing the entire resource because the only real use-case for passing the resource is to make decisions based on its type. 

Passing the entire object might cause people to do questionable things with the resource so we just pass the type name as a string instead. Unfortunately, this makes type checking code a little more cumbersome to write. Instead of `$resource instanceof Foo` we must write `is_a($resourceType, Foo::class, true)`. Moreover, we lose the ability to distinguish between difference instances of `Foo`, but it is supposed no valid use cases exist for this.

The use-case for passing the resource type is applications that want to distinguish between different groups of resources that the API itself does not make. That is, certain applications may wish to group certain members of a provider's resources for application-defined reasons and pass different connectors to them.

---
Must decide whether or not we want this before v4 is released because it's a breaking change otherwise.