### PR TITLE
Added provider fetch exception handler to ImportConnector

### DIFF
--- a/src/Connector/ImportConnector.php
+++ b/src/Connector/ImportConnector.php
@@ -39,4 +39,14 @@ final class ImportConnector
     {
         return $this->connector;
     }
+
+    /**
+     * Sets the exception handler to be called when a recoverable exception is thrown by Connector::fetch().
+     *
+     * @param callable $exceptionHandler Exception handler.
+     */
+    public function setExceptionHandler(callable $exceptionHandler)
+    {
+        $this->context->setProviderFetchExceptionHandler($exceptionHandler);
+    }
 }

--- a/test/Unit/Porter/Connector/ImportConnectorTest.php
+++ b/test/Unit/Porter/Connector/ImportConnectorTest.php
@@ -89,4 +89,20 @@ final class ImportConnectorTest extends \PHPUnit_Framework_TestCase
 
         self::assertSame($wrappedConnector, $connector->getWrappedConnector());
     }
+
+    /**
+     * Tests that setting the provider exception handler twice produces an exception the second time.
+     */
+    public function testSetExceptionHandlerTwice()
+    {
+        $connector = new ImportConnector(
+            $wrappedConnector = \Mockery::mock(Connector::class),
+            FixtureFactory::buildConnectionContext()
+        );
+
+        $connector->setExceptionHandler([$this, __FUNCTION__]);
+
+        $this->setExpectedException(\LogicException::class);
+        $connector->setExceptionHandler([$this, __FUNCTION__]);
+    }
 }


### PR DESCRIPTION
Since connectors now wrap their fetch code in an error trapping block (using `ConnectionContext::retry`), resources no longer have the option of catching low level connector exceptions themselves (they are intercepted by the fetch exception handler). However, resources need a way to determine if a recoverable exception should be promoted to fatal, or receive other special handling, so they now have the option of specifying a *provider fetch exception handler*, which is executed before the user-defined fetch exception handler set in the `ImportSpecification`.