### PR TITLE
Added ConnectorWrapper interface

### DIFF
--- a/src/Connector/CachingConnector.php
+++ b/src/Connector/CachingConnector.php
@@ -10,7 +10,7 @@ use ScriptFUSION\Porter\Cache\MemoryCache;
 /**
  * Wraps a connector to cache fetched data using PSR-6-compliant objects.
  */
-class CachingConnector implements Connector
+class CachingConnector implements Connector, ConnectorWrapper
 {
     /**
      * @var Connector
@@ -35,6 +35,14 @@ class CachingConnector implements Connector
         $this->connector = $connector;
         $this->cache = $cache ?: new MemoryCache;
         $this->cacheKeyGenerator = $cacheKeyGenerator ?: new JsonCacheKeyGenerator;
+    }
+
+    public function __clone()
+    {
+        $this->connector = clone $this->connector;
+
+        /* It doesn't make sense to clone the cache because we want cache state to be shared between imports.
+           We're also not cloning the CacheKeyGenerator because they're expected to be stateless algorithms. */
     }
 
     /**
@@ -86,5 +94,10 @@ class CachingConnector implements Connector
                 CacheKeyGenerator::RESERVED_CHARACTERS
             ));
         }
+    }
+
+    public function getWrappedConnector()
+    {
+        return $this->connector;
     }
 }

--- a/src/Connector/ConnectorWrapper.php
+++ b/src/Connector/ConnectorWrapper.php
@@ -1,0 +1,15 @@
+<?php
+namespace ScriptFUSION\Porter\Connector;
+
+/**
+ * Designates a connector decorator object and provides a method to access the wrapped connector.
+ */
+interface ConnectorWrapper
+{
+    /**
+     * Gets the wrapped connector.
+     *
+     * @return Connector
+     */
+    public function getWrappedConnector();
+}

--- a/src/Connector/ImportConnector.php
+++ b/src/Connector/ImportConnector.php
@@ -10,7 +10,7 @@ use ScriptFUSION\Porter\Connector\FetchExceptionHandler\FetchExceptionHandler;
  *
  * Do not store references to this connector that would prevent it expiring when an import operation ends.
  */
-final class ImportConnector
+final class ImportConnector implements ConnectorWrapper
 {
     private $connector;
 
@@ -22,7 +22,7 @@ final class ImportConnector
             throw CacheUnavailableException::createUnsupported();
         }
 
-        $this->connector = $connector;
+        $this->connector = clone $connector;
         $this->context = $context;
     }
 
@@ -34,11 +34,27 @@ final class ImportConnector
     /**
      * Gets the wrapped connector. Useful for resources to reconfigure connector options during this import.
      *
-     * @return Connector
+     * @return Connector Wrapped connector.
      */
     public function getWrappedConnector()
     {
         return $this->connector;
+    }
+
+    /**
+     * Finds the base connector by traversing the stack of wrapped connectors.
+     *
+     * @return Connector Base connector.
+     */
+    public function findBaseConnector()
+    {
+        $connector = $this->connector;
+
+        while ($connector instanceof ConnectorWrapper) {
+            $connector = $connector->getWrappedConnector();
+        }
+
+        return $connector;
     }
 
     /**

--- a/src/Porter.php
+++ b/src/Porter.php
@@ -119,7 +119,7 @@ class Porter
             );
         }
 
-        $records = $resource->fetch(new ImportConnector(clone $connector, $context));
+        $records = $resource->fetch(new ImportConnector($connector, $context));
 
         if (!$records instanceof \Iterator) {
             throw new ImportException(get_class($resource) . '::fetch() did not return an Iterator.');

--- a/src/Specification/ImportSpecification.php
+++ b/src/Specification/ImportSpecification.php
@@ -80,7 +80,7 @@ class ImportSpecification
     }
 
     /**
-     * Gets the provider name.
+     * Gets the provider service name.
      *
      * @return string Provider name.
      */
@@ -90,7 +90,7 @@ class ImportSpecification
     }
 
     /**
-     * Sets the provider name.
+     * Sets the provider service name.
      *
      * @param string $providerName Provider name.
      *
@@ -211,7 +211,7 @@ class ImportSpecification
     }
 
     /**
-     * Gets the maximum number of fetch attempts per import.
+     * Gets the maximum number of fetch attempts per connection.
      *
      * @return int Maximum fetch attempts.
      */
@@ -221,7 +221,7 @@ class ImportSpecification
     }
 
     /**
-     * Sets the maximum number of fetch attempts per import.
+     * Sets the maximum number of fetch attempts per connection before failure is considered permanent.
      *
      * @param int $attempts Maximum fetch attempts.
      *

--- a/test/Integration/Porter/Connector/CachingConnectorTest.php
+++ b/test/Integration/Porter/Connector/CachingConnectorTest.php
@@ -15,6 +15,9 @@ use ScriptFUSION\Porter\Options\EncapsulatedOptions;
 use ScriptFUSIONTest\FixtureFactory;
 use ScriptFUSIONTest\Stubs\TestOptions;
 
+/**
+ * @see CachingConnector
+ */
 final class CachingConnectorTest extends \PHPUnit_Framework_TestCase
 {
     use MockeryPHPUnitIntegration;
@@ -191,6 +194,24 @@ final class CachingConnectorTest extends \PHPUnit_Framework_TestCase
 
         $this->setExpectedException(InvalidCacheKeyException::class, 'contains one or more reserved characters');
         $connector->fetch($this->context, 'baz');
+    }
+
+    /**
+     * Tests that getting the wrapped connector returns exactly the same connector as constructed with.
+     */
+    public function testGetWrappedConnector()
+    {
+        self::assertSame($this->wrappedConnector, $this->connector->getWrappedConnector());
+    }
+
+    /**
+     * Tests that cloning the caching connector also clones the wrapped connector.
+     */
+    public function testClone()
+    {
+        $clone = clone $this->connector;
+
+        self::assertNotSame($this->wrappedConnector, $clone->getWrappedConnector());
     }
 
     private function createConnector(MockInterface $cache = null, MockInterface $cacheKeyGenerator = null)

--- a/test/Unit/Porter/Connector/ImportConnectorTest.php
+++ b/test/Unit/Porter/Connector/ImportConnectorTest.php
@@ -55,7 +55,7 @@ final class ImportConnectorTest extends \PHPUnit_Framework_TestCase
     public function testFetchCacheEnabled()
     {
         $connector = new ImportConnector(
-            \Mockery::mock(CachingConnector::class)
+            \Mockery::mock(CachingConnector::class, [\Mockery::mock(Connector::class)])
                 ->shouldReceive('fetch')
                 ->andReturn($output = 'foo')
                 ->getMock(),
@@ -79,7 +79,7 @@ final class ImportConnectorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Tests that getting the wrapped connector returns exactly the same connector as constructed with.
+     * Tests that getting the wrapped connector returns a clone of the original connector passed to the constructor.
      */
     public function testGetWrappedConnector()
     {
@@ -88,7 +88,8 @@ final class ImportConnectorTest extends \PHPUnit_Framework_TestCase
             FixtureFactory::buildConnectionContext()
         );
 
-        self::assertSame($wrappedConnector, $connector->getWrappedConnector());
+        self::assertNotSame($wrappedConnector, $connector->getWrappedConnector());
+        self::assertSame(get_class($wrappedConnector), get_class($connector->getWrappedConnector()));
     }
 
     /**

--- a/test/Unit/Porter/Connector/ImportConnectorTest.php
+++ b/test/Unit/Porter/Connector/ImportConnectorTest.php
@@ -4,6 +4,7 @@ namespace ScriptFUSIONTest\Unit\Porter\Connector;
 use ScriptFUSION\Porter\Cache\CacheUnavailableException;
 use ScriptFUSION\Porter\Connector\CachingConnector;
 use ScriptFUSION\Porter\Connector\Connector;
+use ScriptFUSION\Porter\Connector\ConnectorWrapper;
 use ScriptFUSION\Porter\Connector\FetchExceptionHandler\FetchExceptionHandler;
 use ScriptFUSION\Porter\Connector\ImportConnector;
 use ScriptFUSIONTest\FixtureFactory;
@@ -106,5 +107,21 @@ final class ImportConnectorTest extends \PHPUnit_Framework_TestCase
 
         $this->setExpectedException(\LogicException::class);
         $connector->setExceptionHandler($handler);
+    }
+
+    /**
+     * Tests that finding the base connector returns the connector at the bottom of a ConnectorWrapper stack.
+     */
+    public function testFindBaseConnector()
+    {
+        $connector = new ImportConnector(
+            \Mockery::mock(Connector::class, ConnectorWrapper::class)
+                ->shouldReceive('getWrappedConnector')
+                    ->andReturn($baseConnector = \Mockery::mock(Connector::class))
+                ->getMock(),
+            FixtureFactory::buildConnectionContext()
+        );
+
+        self::assertSame($baseConnector, $connector->findBaseConnector());
     }
 }


### PR DESCRIPTION
This final PR for 4.0 RC adds the the missing `__clone()` method and a method to access the wrapped connector in `CachingConnector`. It also adds a new `findBaseConnector()` method to `ImportConnector` to save callers having to call `getWrappedConnector()` multiple times. `getWrappedConnector()` is now specified by the new `ConnectorWrapper` interface.

## Technical changes
* Added missing `CachingConnector::__clone()` method.
* Added `ImportConnector::findBaseConnector()`.
* Changed `CachingConnector` to implement `ConnectorWrapper`.
* Changed `ImportConnector` to clone its connector instead of relying on caller.
* Fixed some `ImportSpecification` docblocks.