### PR TITLE
Forced RecordCollections to return arrays

### DIFF
--- a/src/Collection/RecordCollection.php
+++ b/src/Collection/RecordCollection.php
@@ -16,26 +16,48 @@ abstract class RecordCollection implements \Iterator
         $this->previousCollection = $previousCollection;
     }
 
+    /**
+     * @return array
+     */
     public function current()
     {
-        return $this->records->current();
+        $current = $this->records->current();
+
+        // TODO: Consider removing when dropping PHP 5 support (replace with type hint).
+        if (!is_array($current)) {
+            throw new \RuntimeException('Record collection did not return an array.');
+        }
+
+        return $current;
     }
 
+    /**
+     * @return void
+     */
     public function next()
     {
         $this->records->next();
     }
 
+    /**
+     * @return mixed
+     */
     public function key()
     {
         return $this->records->key();
     }
 
+    /**
+     * @return bool
+     */
     public function valid()
     {
         return $this->records->valid();
     }
 
+    /**
+     * @return void
+     */
     public function rewind()
     {
         $this->records->rewind();

--- a/test/Integration/Porter/Collection/CountableProviderRecordsTest.php
+++ b/test/Integration/Porter/Collection/CountableProviderRecordsTest.php
@@ -4,19 +4,22 @@ namespace ScriptFUSIONTest\Integration\Porter\Collection;
 use ScriptFUSION\Porter\Collection\CountableProviderRecords;
 use ScriptFUSION\Porter\Provider\Resource\ProviderResource;
 
+/**
+ * @see CountableProviderRecords
+ */
 final class CountableProviderRecordsTest extends \PHPUnit_Framework_TestCase
 {
-    public function test()
+    /**
+     * Tests that counting the collection matches the passed count value.
+     */
+    public function testCount()
     {
-        $data = range(1, 10);
-
         $records = new CountableProviderRecords(
-            new \ArrayIterator($data),
-            count($data),
+            new \EmptyIterator,
+            $count = 10,
             \Mockery::mock(ProviderResource::class)
         );
 
-        self::assertCount(count($data), $records);
-        self::assertSame($data, iterator_to_array($records));
+        self::assertCount($count, $records);
     }
 }

--- a/test/Integration/Porter/Specification/StaticDataImportSpecificationTest.php
+++ b/test/Integration/Porter/Specification/StaticDataImportSpecificationTest.php
@@ -13,8 +13,8 @@ final class StaticDataImportSpecificationTest extends \PHPUnit_Framework_TestCas
     public function test()
     {
         $records = (new Porter(\Mockery::spy(ContainerInterface::class)))
-            ->import(new StaticDataImportSpecification(new \ArrayIterator(['foo'])));
+            ->import(new StaticDataImportSpecification(new \ArrayIterator([$output = ['foo']])));
 
-        self::assertSame('foo', $records->current());
+        self::assertSame($output, $records->current());
     }
 }

--- a/test/MockFactory.php
+++ b/test/MockFactory.php
@@ -44,7 +44,7 @@ final class MockFactory
                 ->andReturn(get_class($provider))
             ->shouldReceive('fetch')
                 ->andReturnUsing(function (ImportConnector $connector) {
-                    return new \ArrayIterator([$connector->fetch('foo')]);
+                    return new \ArrayIterator([[$connector->fetch('foo')]]);
                 })
                 ->byDefault()
             ->getMock()

--- a/test/Unit/Porter/Collection/RecordCollectionTest.php
+++ b/test/Unit/Porter/Collection/RecordCollectionTest.php
@@ -3,6 +3,9 @@ namespace ScriptFUSIONTest\Unit\Porter\Collection;
 
 use ScriptFUSION\Porter\Collection\RecordCollection;
 
+/**
+ * @see RecordCollection
+ */
 final class RecordCollectionTest extends \PHPUnit_Framework_TestCase
 {
     public function testFindParent()
@@ -29,5 +32,20 @@ final class RecordCollectionTest extends \PHPUnit_Framework_TestCase
         self::assertSame($collection1, $collection1->findFirstCollection());
         self::assertSame($collection1, $collection2->findFirstCollection());
         self::assertSame($collection1, $collection3->findFirstCollection());
+    }
+
+    /**
+     * Tests that when a RecordCollection yields a non-array datum, an exception is thrown.
+     */
+    public function testNonArrayYield()
+    {
+        /** @var RecordCollection $collection */
+        $collection = \Mockery::mock(
+            RecordCollection::class,
+            [new \ArrayIterator(['foo'])]
+        )->makePartial();
+
+        $this->setExpectedException(\RuntimeException::class);
+        $collection->current();
     }
 }


### PR DESCRIPTION
Instead of just proclaiming it in the documentation, `RecordCollection`s actually enforce the return type of each iteration to be `array`, now.