### PR TITLE
Prevented single record resources being imported with multi-record import methods

### DIFF
--- a/src/IncompatibleResourceException.php
+++ b/src/IncompatibleResourceException.php
@@ -6,13 +6,27 @@ namespace ScriptFUSION\Porter;
 use ScriptFUSION\Porter\Provider\Resource\SingleRecordResource;
 
 /**
- * The exception that is throw when a resource is incompatible with an importOne operation because it is not marked
- * with the single record interface.
+ * The exception that is throw when a resource is incompatible with an import operation.
  */
 final class IncompatibleResourceException extends \LogicException
 {
-    public function __construct()
+    public function __construct(string $message)
     {
-        parent::__construct('Cannot import one: resource does not implement ' . SingleRecordResource::class . '.');
+        parent::__construct($message);
+    }
+
+    public static function createMustImplementInterface(): self
+    {
+        return new self('Cannot import one: resource does not implement ' . SingleRecordResource::class . '.');
+    }
+
+    public static function createMustNotImplementInterface(): self
+    {
+        return new self('This is a single record resource. Try calling importOne() instead.');
+    }
+
+    public static function createMustNotImplementInterfaceAsync(): self
+    {
+        return new self('This is a single record resource. Try calling importOneAsync() instead.');
     }
 }

--- a/test/Integration/PorterAsyncTest.php
+++ b/test/Integration/PorterAsyncTest.php
@@ -33,6 +33,7 @@ final class PorterAsyncTest extends PorterTest
         parent::setUp();
 
         $this->specification = new AsyncImportSpecification($this->resource);
+        $this->singleSpecification = new AsyncImportSpecification($this->singleResource);
     }
 
     /**
@@ -47,11 +48,22 @@ final class PorterAsyncTest extends PorterTest
     }
 
     /**
+     * Tests that when importing a single record resource, an exception is thrown.
+     */
+    public function testImportSingle(): void
+    {
+        $this->expectException(IncompatibleResourceException::class);
+        $this->expectExceptionMessage('importOneAsync()');
+
+        $this->porter->importAsync($this->singleSpecification);
+    }
+
+    /**
      * Tests that the full async import path, via connector, resource and provider, fetches one record correctly.
      */
     public function testImportOneAsync(): \Generator
     {
-        self::assertSame(['foo'], yield $this->porter->importOneAsync($this->specification));
+        self::assertSame(['foo'], yield $this->porter->importOneAsync($this->singleSpecification));
     }
 
     /**
@@ -94,10 +106,10 @@ final class PorterAsyncTest extends PorterTest
      */
     public function testImportOneOfManyAsync(): \Generator
     {
-        $this->resource->shouldReceive('fetchAsync')->andReturn(Iterator\fromIterable([['foo'], ['bar']]));
+        $this->singleResource->shouldReceive('fetchAsync')->andReturn(Iterator\fromIterable([['foo'], ['bar']]));
 
         $this->expectException(ImportException::class);
-        yield $this->porter->importOneAsync($this->specification);
+        yield $this->porter->importOneAsync($this->singleSpecification);
     }
 
     /**

--- a/test/Integration/PorterSyncTest.php
+++ b/test/Integration/PorterSyncTest.php
@@ -184,38 +184,49 @@ final class PorterSyncTest extends PorterTest
         $this->porter->import($this->specification);
     }
 
+    /**
+     * Tests that when importing a single record resource, an exception is thrown.
+     */
+    public function testImportSingle(): void
+    {
+        $this->expectException(IncompatibleResourceException::class);
+        $this->expectExceptionMessage('importOne()');
+
+        $this->porter->import($this->singleSpecification);
+    }
+
     #endregion
 
     #region Import one
 
     public function testImportOne(): void
     {
-        $result = $this->porter->importOne($this->specification);
+        $result = $this->porter->importOne($this->singleSpecification);
 
         self::assertSame(['foo'], $result);
     }
 
     public function testImportOneOfNone(): void
     {
-        $this->resource->shouldReceive('fetch')->andReturn(new \EmptyIterator);
+        $this->singleResource->shouldReceive('fetch')->andReturn(new \EmptyIterator);
 
-        $result = $this->porter->importOne($this->specification);
+        $result = $this->porter->importOne($this->singleSpecification);
 
         self::assertNull($result);
     }
 
     public function testImportOneOfMany(): void
     {
-        $this->resource->shouldReceive('fetch')->andReturn(new \ArrayIterator([['foo'], ['bar']]));
+        $this->singleResource->shouldReceive('fetch')->andReturn(new \ArrayIterator([['foo'], ['bar']]));
 
         $this->expectException(ImportException::class);
-        $this->porter->importOne($this->specification);
+        $this->porter->importOne($this->singleSpecification);
     }
 
     /**
      * Tests that when importing one from a resource not marked with SingleRecordResource, an exception is thrown.
      */
-    public function testImportOneNonSingleAsync(): \Generator
+    public function testImportOneNonSingle(): \Generator
     {
         $this->expectException(IncompatibleResourceException::class);
         $this->expectExceptionMessage(SingleRecordResource::class);
@@ -318,7 +329,7 @@ final class PorterSyncTest extends PorterTest
             ->shouldReceive('fetch')
             ->andReturnUsing(static function (ImportConnector $connector) use ($connectorException): \Generator {
                 $connector->setRecoverableExceptionHandler(new StatelessRecoverableExceptionHandler(
-                    function (\Exception $exception) use ($connectorException) {
+                    static function (\Exception $exception) use ($connectorException) {
                         self::assertSame($connectorException, $exception);
 
                         throw new \RuntimeException('This exception is thrown by the provider handler.');
@@ -330,7 +341,7 @@ final class PorterSyncTest extends PorterTest
         ;
 
         $this->expectException(\RuntimeException::class);
-        $this->porter->importOne($this->specification);
+        $this->porter->importOne($this->singleSpecification);
     }
 
     #endregion

--- a/test/Integration/PorterTest.php
+++ b/test/Integration/PorterTest.php
@@ -38,6 +38,11 @@ abstract class PorterTest extends AsyncTestCase
     protected $resource;
 
     /**
+     * @var ProviderResource|AsyncResource|MockInterface
+     */
+    protected $singleResource;
+
+    /**
      * @var Connector|AsyncConnector|MockInterface
      */
     protected $connector;
@@ -46,6 +51,11 @@ abstract class PorterTest extends AsyncTestCase
      * @var ImportSpecification|AsyncImportSpecification
      */
     protected $specification;
+
+    /**
+     * @var ImportSpecification|AsyncImportSpecification
+     */
+    protected $singleSpecification;
 
     /**
      * @var ContainerInterface|MockInterface
@@ -62,6 +72,8 @@ abstract class PorterTest extends AsyncTestCase
         $this->connector = $this->provider->getConnector();
         $this->resource = MockFactory::mockResource($this->provider);
         $this->specification = new ImportSpecification($this->resource);
+        $this->singleResource = MockFactory::mockSingleRecordResource($this->provider);
+        $this->singleSpecification = new ImportSpecification($this->singleResource);
     }
 
     /**

--- a/test/MockFactory.php
+++ b/test/MockFactory.php
@@ -53,9 +53,15 @@ final class MockFactory
     /**
      * @return ProviderResource|AsyncResource|MockInterface
      */
-    public static function mockResource(Provider $provider, \Iterator $return = null)
+    public static function mockResource(Provider $provider, \Iterator $return = null, bool $single = false)
     {
-        $resource = \Mockery::mock(ProviderResource::class, AsyncResource::class, SingleRecordResource::class)
+        /** @var ProviderResource|AsyncResource|MockInterface $resource */
+        $resource = \Mockery::mock(
+            ...array_merge(
+                [ProviderResource::class, AsyncResource::class],
+                $single ? [SingleRecordResource::class] : []
+            )
+        )
             ->shouldReceive('getProviderClassName')
                 ->andReturn(\get_class($provider))
             ->shouldReceive('fetch')
@@ -78,6 +84,14 @@ final class MockFactory
         }
 
         return $resource;
+    }
+
+    /**
+     * @return ProviderResource|AsyncResource|MockInterface
+     */
+    public static function mockSingleRecordResource(Provider $provider)
+    {
+        return self::mockResource($provider, null, true);
     }
 
     /**


### PR DESCRIPTION
Continuation of #65.

It is not useful to have a marker interface for single record resources that is only required by `importOne()`/`importOneAsync()` because one can just mark _all_ resources as single record and they now work with all import methods, thus obviating its usefulness. By rejecting single record resources from `import()`/`importAsync()`, the interface now has the useful purpose of ensuring the correct method is called for single and multi-record resources respectively.