### PR TITLE
Added Provider to ImportConnector to facilitate accessing Provider dependencies during fetch

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,11 +9,13 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         php:
           - 7.3
           - 7.4
           - 8.0
+          - 8.1
         dependencies:
           - hi
           - lo

--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,11 @@
   },
   "require-dev": {
     "amphp/phpunit-util": "^1.1",
-    "infection/infection": ">=0.18,<1",
+    "infection/infection": ">=0.18,<0.26",
     "justinrainbow/json-schema": "^5.2.10",
     "mockery/mockery": "^1.4.2",
     "phpunit/php-code-coverage": "^9.2.5",
-    "phpunit/phpunit": "^9.5",
+    "phpunit/phpunit": "^9.5.13",
     "thecodingmachine/safe": "^1.3.3"
   },
   "suggest" : {
@@ -46,6 +46,9 @@
     "mutation": "infection --configuration=test/infection.json"
   },
   "config": {
-    "sort-packages": true
+    "sort-packages": true,
+    "allow-plugins": {
+      "infection/extension-installer": false
+    }
   }
 }

--- a/src/Connector/ImportConnectorFactory.php
+++ b/src/Connector/ImportConnectorFactory.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 namespace ScriptFUSION\Porter\Connector;
 
 use ScriptFUSION\Async\Throttle\NullThrottle;
+use ScriptFUSION\Porter\Provider\AsyncProvider;
+use ScriptFUSION\Porter\Provider\Provider;
 use ScriptFUSION\Porter\Specification\AsyncImportSpecification;
 use ScriptFUSION\Porter\Specification\Specification;
 use ScriptFUSION\StaticClass;
@@ -16,12 +18,13 @@ final class ImportConnectorFactory
     use StaticClass;
 
     /**
+     * @param Provider|AsyncProvider $provider
      * @param Connector|AsyncConnector $connector
      * @param Specification $specification
      *
      * @return ImportConnector
      */
-    public static function create($connector, Specification $specification): ImportConnector
+    public static function create($provider, $connector, Specification $specification): ImportConnector
     {
         if ($specification instanceof AsyncImportSpecification) {
             $throttle = $specification->getThrottle();
@@ -32,6 +35,7 @@ final class ImportConnectorFactory
         }
 
         return new ImportConnector(
+            $provider,
             $connector,
             $specification->getRecoverableExceptionHandler(),
             $specification->getMaxFetchAttempts(),

--- a/src/Porter.php
+++ b/src/Porter.php
@@ -120,7 +120,9 @@ class Porter
             ));
         }
 
-        $records = $resource->fetch(ImportConnectorFactory::create($provider->getConnector(), $specification));
+        $records = $resource->fetch(
+            ImportConnectorFactory::create($provider, $provider->getConnector(), $specification)
+        );
 
         if (!$records instanceof ProviderRecords) {
             $records = $this->createProviderRecords($records, $specification->getResource());
@@ -201,7 +203,7 @@ class Porter
         }
 
         $records = $resource->fetchAsync(
-            ImportConnectorFactory::create($provider->getAsyncConnector(), $specification)
+            ImportConnectorFactory::create($provider, $provider->getAsyncConnector(), $specification)
         );
 
         if (!$records instanceof AsyncProviderRecords) {

--- a/src/Provider/Resource/AsyncResource.php
+++ b/src/Provider/Resource/AsyncResource.php
@@ -19,7 +19,7 @@ interface AsyncResource
     public function getProviderClassName(): string;
 
     /**
-     * Fetches data using the the specified connector and presents its data as an enumerable series.
+     * Fetches data using the specified connector and presents its data as an enumerable series.
      *
      * @param ImportConnector $connector Connector.
      *

--- a/src/Provider/Resource/ProviderResource.php
+++ b/src/Provider/Resource/ProviderResource.php
@@ -18,7 +18,7 @@ interface ProviderResource
     public function getProviderClassName(): string;
 
     /**
-     * Fetches data using the the specified connector and presents it as an iterable series.
+     * Fetches data using the specified connector and presents it as an iterable series.
      *
      * @param ImportConnector $connector Connector.
      *

--- a/test/FixtureFactory.php
+++ b/test/FixtureFactory.php
@@ -17,9 +17,9 @@ final class FixtureFactory
     public static function buildImportConnector(
         Connector $connector,
         RecoverableExceptionHandler $recoverableExceptionHandler = null,
+        Provider $provider = null,
         int $maxFetchAttempts = ImportSpecification::DEFAULT_FETCH_ATTEMPTS,
-        bool $mustCache = false,
-        Provider $provider = null
+        bool $mustCache = false
     ): ImportConnector {
         return new ImportConnector(
             $provider ?? \Mockery::mock(Provider::class),

--- a/test/FixtureFactory.php
+++ b/test/FixtureFactory.php
@@ -6,6 +6,7 @@ namespace ScriptFUSIONTest;
 use ScriptFUSION\Porter\Connector\Connector;
 use ScriptFUSION\Porter\Connector\ImportConnector;
 use ScriptFUSION\Porter\Connector\Recoverable\RecoverableExceptionHandler;
+use ScriptFUSION\Porter\Provider\Provider;
 use ScriptFUSION\Porter\Specification\ImportSpecification;
 use ScriptFUSION\StaticClass;
 
@@ -17,9 +18,11 @@ final class FixtureFactory
         Connector $connector,
         RecoverableExceptionHandler $recoverableExceptionHandler = null,
         int $maxFetchAttempts = ImportSpecification::DEFAULT_FETCH_ATTEMPTS,
-        bool $mustCache = false
+        bool $mustCache = false,
+        Provider $provider = null
     ): ImportConnector {
         return new ImportConnector(
+            $provider ?? \Mockery::mock(Provider::class),
             $connector,
             $recoverableExceptionHandler ?: \Mockery::spy(RecoverableExceptionHandler::class),
             $maxFetchAttempts,

--- a/test/Functional/ThrottlePrecedenceHierarchyTest.php
+++ b/test/Functional/ThrottlePrecedenceHierarchyTest.php
@@ -25,8 +25,11 @@ final class ThrottlePrecedenceHierarchyTest extends AsyncTestCase
     use MockeryPHPUnitIntegration;
 
     private $specificationThrottle;
+
     private $connectorThrottle;
+
     private $specification;
+
     private $provider;
 
     protected function setUp(): void

--- a/test/Functional/ThrottlePrecedenceHierarchyTest.php
+++ b/test/Functional/ThrottlePrecedenceHierarchyTest.php
@@ -50,7 +50,11 @@ final class ThrottlePrecedenceHierarchyTest extends AsyncTestCase
         $this->specificationThrottle->expects('await')->once()->andReturn(new Success());
         $this->connectorThrottle->expects('await')->never();
 
-        $connector = ImportConnectorFactory::create($this->provider->getAsyncConnector(), $this->specification);
+        $connector = ImportConnectorFactory::create(
+            $this->provider,
+            $this->provider->getAsyncConnector(),
+            $this->specification
+        );
 
         yield $connector->fetchAsync(\Mockery::mock(AsyncDataSource::class));
     }
@@ -64,7 +68,11 @@ final class ThrottlePrecedenceHierarchyTest extends AsyncTestCase
         $this->specificationThrottle->expects('await')->never();
         $this->connectorThrottle->expects('await')->once()->andReturn(new Success());
 
-        $connector = ImportConnectorFactory::create($this->mockThrottledConnector(), $this->specification);
+        $connector = ImportConnectorFactory::create(
+            $this->provider,
+            $this->mockThrottledConnector(),
+            $this->specification
+        );
 
         yield $connector->fetchAsync(\Mockery::mock(AsyncDataSource::class));
     }
@@ -79,7 +87,11 @@ final class ThrottlePrecedenceHierarchyTest extends AsyncTestCase
         $this->specificationThrottle->expects('await')->once()->andReturn(new Success());
         $this->connectorThrottle->expects('await')->never();
 
-        $connector = ImportConnectorFactory::create($this->mockThrottledConnector(), $this->specification);
+        $connector = ImportConnectorFactory::create(
+            $this->provider,
+            $this->mockThrottledConnector(),
+            $this->specification
+        );
 
         yield $connector->fetchAsync(\Mockery::mock(AsyncDataSource::class));
     }

--- a/test/Integration/PorterAsyncTest.php
+++ b/test/Integration/PorterAsyncTest.php
@@ -12,7 +12,6 @@ use ScriptFUSION\Porter\Collection\AsyncPorterRecords;
 use ScriptFUSION\Porter\Collection\AsyncRecordCollection;
 use ScriptFUSION\Porter\Collection\CountableAsyncPorterRecords;
 use ScriptFUSION\Porter\Collection\CountableAsyncProviderRecords;
-use ScriptFUSION\Porter\Collection\PorterRecords;
 use ScriptFUSION\Porter\ForeignResourceException;
 use ScriptFUSION\Porter\ImportException;
 use ScriptFUSION\Porter\IncompatibleProviderException;

--- a/test/Unit/Connector/ImportConnectorTest.php
+++ b/test/Unit/Connector/ImportConnectorTest.php
@@ -13,6 +13,7 @@ use ScriptFUSION\Porter\Connector\ConnectorWrapper;
 use ScriptFUSION\Porter\Connector\DataSource;
 use ScriptFUSION\Porter\Connector\ImportConnector;
 use ScriptFUSION\Porter\Connector\Recoverable\RecoverableExceptionHandler;
+use ScriptFUSION\Porter\Provider\Provider;
 use ScriptFUSIONTest\FixtureFactory;
 
 /**
@@ -74,6 +75,7 @@ final class ImportConnectorTest extends TestCase
                 ->andReturn($output = 'foo')
                 ->getMock(),
             null,
+            null,
             1,
             true
         );
@@ -108,7 +110,7 @@ final class ImportConnectorTest extends TestCase
     {
         $this->expectException(CacheUnavailableException::class);
 
-        FixtureFactory::buildImportConnector(\Mockery::mock(Connector::class), null, 1, true);
+        FixtureFactory::buildImportConnector(\Mockery::mock(Connector::class), null, null, 1, true);
     }
 
     /**
@@ -150,5 +152,19 @@ final class ImportConnectorTest extends TestCase
         );
 
         self::assertSame($baseConnector, $connector->findBaseConnector());
+    }
+
+    /**
+     * Tests that the provider passed to the constructor can be retrieved via a getter.
+     */
+    public function testGetProvider(): void
+    {
+        $connector = FixtureFactory::buildImportConnector(
+            \Mockery::mock(Connector::class),
+            null,
+            $provider = \Mockery::mock(Provider::class)
+        );
+
+        self::assertSame($provider, $connector->getProvider());
     }
 }

--- a/test/Unit/Provider/Resource/IncompatibleResourceExceptionTest.php
+++ b/test/Unit/Provider/Resource/IncompatibleResourceExceptionTest.php
@@ -3,8 +3,8 @@ declare(strict_types=1);
 
 namespace ScriptFUSIONTest\Unit\Provider\Resource;
 
-use ScriptFUSION\Porter\IncompatibleResourceException;
 use PHPUnit\Framework\TestCase;
+use ScriptFUSION\Porter\IncompatibleResourceException;
 use ScriptFUSION\Porter\Provider\Resource\SingleRecordResource;
 
 /**


### PR DESCRIPTION
A common problem is building URLs from a base path and other component parts. Porter used to provide such URL building tools, but in order to be protocol agnostic, this was dropped in [4.0](https://github.com/ScriptFUSION/Porter/releases/tag/4.0.0). Implementations are expecting to provide their own URL building utility methods as required, which commonly consist of adding static methods to the Provider, but since the base path may be defined as a dependency to be injected, static methods will not always suffice.

Since `HttpDataSource` is final, it cannot be extended to support base paths. Since resources are expected to be constructed inline, they cannot receive dependencies; only the provider can be used to receive dependencies, including the base path configuration parameter, which should also be considered a dependency. However, injecting dependencies into the provider is of no use to resources since resources only have access to the connector and the connector cannot easily be override to provide base path features either.

By making the Provider available during `ProviderResource::fetch()`, via the `ImportConnector`, instance methods can be called to build URLs from dependencies, including injected configuration parameters, without having to rely on static methods.

Perhaps the provider should be passed as a second argument to `fetch()`, but this is a backwards-compatible mechanism to expose the Provider during imports.